### PR TITLE
Add turbo build orchestration and dist manifest tooling

### DIFF
--- a/.changeset/loud-heads-sip.md
+++ b/.changeset/loud-heads-sip.md
@@ -1,0 +1,8 @@
+---
+"@listee/types": patch
+"@listee/auth": patch
+"@listee/api": patch
+"@listee/db": patch
+---
+
+Update build tooling to use Turbo, TypeScript 5.6, rimraf clean scripts, and reusable dist manifest generation

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# turborepo
+.turbo

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
       "name": "listee-libs",
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
-        "@changesets/cli": "^2.29.7",
+        "@changesets/cli": "2.29.7",
         "@types/bun": "1.2.22",
-        "turbo": "^2.5.8",
+        "turbo": "2.5.8",
         "typescript": "5.6.3",
       },
     },

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@biomejs/biome": "2.2.4",
         "@changesets/cli": "2.29.7",
         "@types/bun": "1.2.22",
+        "rimraf": "6.0.1",
         "turbo": "2.5.8",
         "typescript": "5.6.3",
       },
@@ -108,6 +109,12 @@
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.2", "", { "dependencies": { "chardet": "^2.1.0", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ=="],
 
+    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@listee/api": ["@listee/api@workspace:packages/api"],
 
     "@listee/auth": ["@listee/auth@workspace:packages/auth"],
@@ -136,6 +143,8 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
@@ -150,6 +159,10 @@
 
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
@@ -159,6 +172,10 @@
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
     "drizzle-orm": ["drizzle-orm@0.44.5", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-jBe37K7d8ZSKptdKfakQFdeljtu3P2Cbo7tJoJSVZADzIKOBo9IAJPOmMsH2bZl90bZgh8FQlD8BjxXA/zuBkQ=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -174,7 +191,11 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
+
+    "glob": ["glob@11.0.3", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.0.3", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -192,6 +213,8 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
@@ -201,6 +224,8 @@
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
 
     "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
@@ -212,9 +237,15 @@
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
+    "lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -230,11 +261,15 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -258,6 +293,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rimraf": ["rimraf@6.0.1", "", { "dependencies": { "glob": "^11.0.0", "package-json-from-dist": "^1.0.0" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -276,7 +313,13 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -306,6 +349,12 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -313,5 +362,23 @@
     "@manypkg/get-packages/@changesets/types": ["@changesets/types@4.1.0", "", {}, "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw=="],
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
+    "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@changesets/cli": "^2.29.7",
         "@types/bun": "1.2.22",
         "turbo": "^2.5.8",
+        "typescript": "5.6.3",
       },
     },
     "packages/api": {
@@ -296,6 +297,8 @@
     "turbo-windows-64": ["turbo-windows-64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-3YdcaW34TrN1AWwqgYL9gUqmZsMT4T7g8Y5Azz+uwwEJW+4sgcJkIi9pYFyU4ZBSjBvkfuPZkGgfStir5BBDJQ=="],
 
     "turbo-windows-arm64": ["turbo-windows-arm64@2.5.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-eFC5XzLmgXJfnAK3UMTmVECCwuBcORrWdewoiXBnUm934DY6QN8YowC/srhNnROMpaKaqNeRpoB5FxCww3eteQ=="],
+
+    "typescript": ["typescript@5.6.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="],
 
     "undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,12 @@
         "@biomejs/biome": "2.2.4",
         "@changesets/cli": "^2.29.7",
         "@types/bun": "1.2.22",
+        "turbo": "^2.5.8",
       },
     },
     "packages/api": {
       "name": "@listee/api",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@listee/auth": "workspace:*",
         "@listee/db": "workspace:*",
@@ -21,7 +22,7 @@
     },
     "packages/auth": {
       "name": "@listee/auth",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@listee/types": "workspace:^",
         "jose": "catalog:",
@@ -29,7 +30,7 @@
     },
     "packages/db": {
       "name": "@listee/db",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "postgres": "catalog:",
@@ -37,7 +38,7 @@
     },
     "packages/types": {
       "name": "@listee/types",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@listee/db": "workspace:^",
       },
@@ -281,6 +282,20 @@
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "turbo": ["turbo@2.5.8", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.8", "turbo-darwin-arm64": "2.5.8", "turbo-linux-64": "2.5.8", "turbo-linux-arm64": "2.5.8", "turbo-windows-64": "2.5.8", "turbo-windows-arm64": "2.5.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w=="],
+
+    "turbo-darwin-64": ["turbo-darwin-64@2.5.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Dh5bCACiHO8rUXZLpKw+m3FiHtAp2CkanSyJre+SInEvEr5kIxjGvCK/8MFX8SFRjQuhjtvpIvYYZJB4AGCxNQ=="],
+
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.5.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-f1H/tQC9px7+hmXn6Kx/w8Jd/FneIUnvLlcI/7RGHunxfOkKJKvsoiNzySkoHQ8uq1pJnhJ0xNGTlYM48ZaJOQ=="],
+
+    "turbo-linux-64": ["turbo-linux-64@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-hMyvc7w7yadBlZBGl/bnR6O+dJTx3XkTeyTTH4zEjERO6ChEs0SrN8jTFj1lueNXKIHh1SnALmy6VctKMGnWfw=="],
+
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-LQELGa7bAqV2f+3rTMRPnj5G/OHAe2U+0N9BwsZvfMvHSUbsQ3bBMWdSQaYNicok7wOZcHjz2TkESn1hYK6xIQ=="],
+
+    "turbo-windows-64": ["turbo-windows-64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-3YdcaW34TrN1AWwqgYL9gUqmZsMT4T7g8Y5Azz+uwwEJW+4sgcJkIi9pYFyU4ZBSjBvkfuPZkGgfStir5BBDJQ=="],
+
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.5.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-eFC5XzLmgXJfnAK3UMTmVECCwuBcORrWdewoiXBnUm934DY6QN8YowC/srhNnROMpaKaqNeRpoB5FxCww3eteQ=="],
 
     "undici-types": ["undici-types@7.12.0", "", {}, "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,0 @@
-[alias]
-"@listee/api" = "./packages/api/src/index.ts"
-"@listee/auth" = "./packages/auth/src/index.ts"
-"@listee/db" = "./packages/db/src/index.ts"
-"@listee/types" = "./packages/types/src/index.ts"

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[alias]
+"@listee/api" = "./packages/api/src/index.ts"
+"@listee/auth" = "./packages/auth/src/index.ts"
+"@listee/db" = "./packages/db/src/index.ts"
+"@listee/types" = "./packages/types/src/index.ts"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@biomejs/biome": "2.2.4",
     "@changesets/cli": "2.29.7",
     "@types/bun": "1.2.22",
+    "rimraf": "6.0.1",
     "turbo": "2.5.8",
     "typescript": "5.6.3"
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@biomejs/biome": "2.2.4",
     "@changesets/cli": "^2.29.7",
     "@types/bun": "1.2.22",
-    "turbo": "^2.5.8"
+    "turbo": "^2.5.8",
+    "typescript": "5.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,14 @@
     "test": "bun test",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "build": "turbo run build",
+    "clean": "turbo run clean"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@changesets/cli": "^2.29.7",
-    "@types/bun": "1.2.22"
+    "@types/bun": "1.2.22",
+    "turbo": "^2.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
-    "@changesets/cli": "^2.29.7",
+    "@changesets/cli": "2.29.7",
     "@types/bun": "1.2.22",
-    "turbo": "^2.5.8",
+    "turbo": "2.5.8",
     "typescript": "5.6.3"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "files": ["dist"],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",
     "postbuild": "cp package.json dist/"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",
-    "postbuild": "cp package.json dist/"
+    "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
     "@listee/auth": "workspace:*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,15 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "tsc --project tsconfig.build.json",
-    "clean": "rm -rf dist"
+    "postbuild": "cp package.json dist/"
   },
   "dependencies": {
     "@listee/auth": "workspace:*",

--- a/packages/api/src/repositories/task-repository.ts
+++ b/packages/api/src/repositories/task-repository.ts
@@ -1,12 +1,11 @@
 import type { Database } from "@listee/db";
-import { tasks } from "@listee/db";
+import { eq, tasks } from "@listee/db";
 import type {
   FindTaskRepositoryParams,
   ListTasksRepositoryParams,
   Task,
   TaskRepository,
 } from "@listee/types";
-import { eq } from "drizzle-orm";
 
 export function createTaskRepository(db: Database): TaskRepository {
   async function listByCategory(

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["dist", "src/**/*.test.ts"]
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "paths": {
+      "@listee/auth": ["../auth/dist"],
+      "@listee/db": ["../db/dist"],
+      "@listee/types": ["../types/dist"]
+    }
+  },
+  "include": ["src/**/*"]
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,13 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "dist",
-    "rootDirs": ["src", "../db/src", "../auth/src", "../types/src"],
+    "rootDir": "src",
     "verbatimModuleSyntax": true,
-    "types": ["@types/bun"]
+    "moduleResolution": "Bundler",
+    "types": ["@types/bun"],
+    "paths": {
+      "@listee/auth": ["../auth/src"],
+      "@listee/db": ["../db/src"],
+      "@listee/types": ["../types/src"]
+    }
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["dist"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts", "**/__tests__/**"]
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -3,15 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "tsc --project tsconfig.build.json",
-    "clean": "rm -rf dist"
+    "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
     "@listee/types": "workspace:^",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "files": ["dist"],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "dist",
-    "verbatimModuleSyntax": true
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@listee/types": ["../types/src"]
+    }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "**/*.test.ts", "**/__tests__/**"]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,15 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
+    "clean": "rm -rf dist",
     "build": "tsc --project tsconfig.build.json",
-    "clean": "rm -rf dist"
+    "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
     "drizzle-orm": "catalog:",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "files": ["dist"],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },

--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -72,6 +72,31 @@ mock.module("postgres", () => ({
 
 mock.module("drizzle-orm", () => ({
   sql: sqlTag,
+  eq: (...values: Array<unknown>) => ({
+    kind: "predicate",
+    operator: "eq",
+    values,
+  }),
+  and: (...values: Array<unknown>) => ({
+    kind: "predicate",
+    operator: "and",
+    values,
+  }),
+  or: (...values: Array<unknown>) => ({
+    kind: "predicate",
+    operator: "or",
+    values,
+  }),
+  lt: (...values: Array<unknown>) => ({
+    kind: "predicate",
+    operator: "lt",
+    values,
+  }),
+  desc: (value: unknown) => ({
+    kind: "order",
+    direction: "desc",
+    value,
+  }),
 }));
 
 mock.module("drizzle-orm/postgres-js", () => ({

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -213,7 +213,7 @@ export function createDrizzle(
   return createRlsClient(token, options);
 }
 
-export { sql } from "drizzle-orm";
+export { and, desc, eq, lt, or, sql } from "drizzle-orm";
 
 export * from "./schema/index.js";
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -216,3 +216,7 @@ export function createDrizzle(
 export { sql } from "drizzle-orm";
 
 export * from "./schema/index.js";
+
+const schemaModuleUrl = new URL("./schema/index.js", import.meta.url);
+
+export const schemaPath = schemaModuleUrl.pathname;

--- a/packages/db/tsconfig.build.json
+++ b/packages/db/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["dist", "**/*.test.ts", "**/__tests__/**"],
-  "include": ["src/**/*.ts"]
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"]
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src",
     "verbatimModuleSyntax": true,
+    "moduleResolution": "Bundler",
     "types": ["@types/bun"]
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
-  "exclude": ["dist"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts", "**/__tests__/**"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "files": ["dist"],
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",
     "postbuild": "cp package.json dist/"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",
-    "postbuild": "cp package.json dist/"
+    "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
     "@listee/db": "workspace:^"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,15 +3,13 @@
   "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc --project tsconfig.json",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "build": "tsc --project tsconfig.build.json",
+    "postbuild": "cp package.json dist/"
   },
   "dependencies": {
     "@listee/db": "workspace:^"

--- a/packages/types/tsconfig.build.json
+++ b/packages/types/tsconfig.build.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "declarationMap": true,
     "paths": {
-      "@listee/types": ["../types/dist"]
+      "@listee/db": ["../db/dist"]
     }
   },
   "include": ["src/**/*"]

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "dist",
-    "verbatimModuleSyntax": true
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@listee/db": ["../db/src"]
+    }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "**/*.test.ts", "**/__tests__/**"]
 }

--- a/scripts/write-dist-manifest.mjs
+++ b/scripts/write-dist-manifest.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const distFolderName = "dist";
+const dotDistPrefix = `./${distFolderName}/`;
+const distPrefix = `${distFolderName}/`;
+
+const resolvePackageRoot = () => {
+  const [relativePath] = process.argv.slice(2);
+  if (relativePath) {
+    return resolve(process.cwd(), relativePath);
+  }
+  return process.cwd();
+};
+
+const normalizeEntryPoint = (value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+  if (value.startsWith(dotDistPrefix)) {
+    return `./${value.slice(dotDistPrefix.length)}`;
+  }
+  if (value.startsWith(distPrefix)) {
+    return `./${value.slice(distPrefix.length)}`;
+  }
+  return value;
+};
+
+const normalizeExports = (value) => {
+  if (typeof value === "string") {
+    return normalizeEntryPoint(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeExports(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entryValue]) => [
+        key,
+        normalizeExports(entryValue),
+      ]),
+    );
+  }
+  return value;
+};
+
+const packageRoot = resolvePackageRoot();
+const sourceManifestPath = resolve(packageRoot, "package.json");
+const distDirectory = resolve(packageRoot, distFolderName);
+const distManifestPath = resolve(distDirectory, "package.json");
+
+const rawManifest = await readFile(sourceManifestPath, "utf8");
+const manifest = JSON.parse(rawManifest);
+
+const distManifest = { ...manifest };
+
+distManifest.main =
+  distManifest.main !== undefined
+    ? normalizeEntryPoint(distManifest.main)
+    : "./index.js";
+
+if (distManifest.module !== undefined) {
+  distManifest.module = normalizeEntryPoint(distManifest.module);
+}
+
+if (distManifest.types !== undefined) {
+  distManifest.types = normalizeEntryPoint(distManifest.types);
+}
+
+if (distManifest.typings !== undefined) {
+  distManifest.typings = normalizeEntryPoint(distManifest.typings);
+}
+
+if (distManifest.exports !== undefined) {
+  distManifest.exports = normalizeExports(distManifest.exports);
+}
+
+delete distManifest.scripts;
+delete distManifest.files;
+
+await mkdir(distDirectory, { recursive: true });
+const serialized = `${JSON.stringify(distManifest, null, 2)}\n`;
+await writeFile(distManifestPath, serialized);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,10 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@listee/auth": ["packages/auth/src/index.ts"],
-      "@listee/db": ["packages/db/src/index.ts"],
-      "@listee/api": ["packages/api/src/index.ts"],
-      "@listee/types": ["packages/types/src/index.ts"]
+      "@listee/auth": ["packages/auth/src"],
+      "@listee/db": ["packages/db/src"],
+      "@listee/api": ["packages/api/src"],
+      "@listee/types": ["packages/types/src"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "cache": true
+    },
+    "clean": {}
+  }
+}


### PR DESCRIPTION
  ## Summary
  - add turbo as the workspace build and clean orchestrator
  - align package build scripts to emit normalized dist manifests after TypeScript builds
  - expose Drizzle utilities from `@listee/db` so API packages no longer import `drizzle-orm` directly
  - normalize cursor decoding to handle base64url safely and bump the repo-wide TypeScript toolchain to 5.6

  ## Testing
  - bun x tsc -b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated Turbo for build system management and caching optimization.
  * Standardized TypeScript configuration and build scripts across packages.
  * Updated build tooling to use modern utilities for cleaner, more maintainable builds.
  * Added automated distribution manifest generation.

* **Tests**
  * Enhanced test mocks for database query operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->