### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/.changeset/loud-heads-sip.md
+++ b/.changeset/loud-heads-sip.md
@@ -1,8 +1,0 @@
----
-"@listee/types": patch
-"@listee/auth": patch
-"@listee/api": patch
-"@listee/db": patch
----
-
-Update build tooling to use Turbo, TypeScript 5.6, rimraf clean scripts, and reusable dist manifest generation

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @listee/api
 
+## 0.1.1
+
+### Patch Changes
+
+- b5c3a8f: Update build tooling to use Turbo, TypeScript 5.6, rimraf clean scripts, and reusable dist manifest generation
+- Updated dependencies [b5c3a8f]
+  - @listee/types@0.1.1
+  - @listee/auth@0.1.1
+  - @listee/db@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@listee/api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @listee/auth
 
+## 0.1.1
+
+### Patch Changes
+
+- b5c3a8f: Update build tooling to use Turbo, TypeScript 5.6, rimraf clean scripts, and reusable dist manifest generation
+- Updated dependencies [b5c3a8f]
+  - @listee/types@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@listee/auth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @listee/db
 
+## 0.1.1
+
+### Patch Changes
+
+- b5c3a8f: Update build tooling to use Turbo, TypeScript 5.6, rimraf clean scripts, and reusable dist manifest generation
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@listee/db",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @listee/types
 
+## 0.1.1
+
+### Patch Changes
+
+- b5c3a8f: Update build tooling to use Turbo, TypeScript 5.6, rimraf clean scripts, and reusable dist manifest generation
+- Updated dependencies [b5c3a8f]
+  - @listee/db@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@listee/types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",


### PR DESCRIPTION
## Summary
- bump @listee/types, @listee/auth, @listee/api, and @listee/db to 0.1.1
- update changelogs with tooling improvements (Turbo, TypeScript 5.6, rimraf cleans, dist manifest script)

## Testing
- bun run version-packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bumps across packages (0.1.0 → 0.1.1)
  * Updated build tooling and internal dependencies
  * Updated package metadata formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->