### PR TITLE
Add Supabase account provisioning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/api": {
       "name": "@listee/api",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@listee/auth": "workspace:*",
         "@listee/db": "workspace:*",
@@ -24,15 +24,16 @@
     },
     "packages/auth": {
       "name": "@listee/auth",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
+        "@listee/db": "workspace:^",
         "@listee/types": "workspace:^",
         "jose": "catalog:",
       },
     },
     "packages/db": {
       "name": "@listee/db",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "postgres": "catalog:",
@@ -40,7 +41,7 @@
     },
     "packages/types": {
       "name": "@listee/types",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@listee/db": "workspace:^",
       },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,6 +14,7 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
+    "@listee/db": "workspace:^",
     "@listee/types": "workspace:^",
     "jose": "catalog:"
   }

--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -1,10 +1,10 @@
 import type { Database, RlsClient, RlsTransaction } from "@listee/db";
 import {
-  DEFAULT_CATEGORY_KIND,
-  DEFAULT_CATEGORY_NAME,
   and,
   categories,
   createRlsClient,
+  DEFAULT_CATEGORY_KIND,
+  DEFAULT_CATEGORY_NAME,
   eq,
   profiles,
 } from "@listee/db";

--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -1,0 +1,106 @@
+import type { Database, RlsClient, RlsTransaction } from "@listee/db";
+import {
+  DEFAULT_CATEGORY_KIND,
+  DEFAULT_CATEGORY_NAME,
+  and,
+  categories,
+  createRlsClient,
+  eq,
+  profiles,
+} from "@listee/db";
+import type { SupabaseToken } from "@listee/types";
+
+interface ProvisionAccountParams {
+  readonly userId: string;
+  readonly token: SupabaseToken;
+  readonly email?: string | null;
+}
+
+export interface AccountProvisioner {
+  provision(params: ProvisionAccountParams): Promise<void>;
+}
+
+export interface AccountProvisionerDependencies {
+  readonly database?: Database;
+  readonly createRlsClient?: (token: SupabaseToken) => RlsClient;
+  readonly defaultCategoryName?: string;
+  readonly defaultCategoryKind?: string;
+}
+
+function resolveEmail(
+  email: string | null | undefined,
+  userId: string,
+): string {
+  if (typeof email === "string") {
+    const trimmed = email.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  // Some Supabase-issued tokens (e.g. service_role, custom tokens, or providers
+  // without email claims) omit the email field. We still need a non-null value
+  // to satisfy the profiles.email constraint, so we fall back to a placeholder
+  // that is stable per user ID.
+  return `${userId}@placeholder.invalid`;
+}
+
+function resolveCreateRlsClient(
+  dependencies: AccountProvisionerDependencies,
+): (token: SupabaseToken) => RlsClient {
+  if (dependencies.createRlsClient !== undefined) {
+    return dependencies.createRlsClient;
+  }
+
+  return (token: SupabaseToken) =>
+    createRlsClient(token, { database: dependencies.database });
+}
+
+export function createAccountProvisioner(
+  dependencies: AccountProvisionerDependencies = {},
+): AccountProvisioner {
+  const createClient = resolveCreateRlsClient(dependencies);
+  const defaultCategoryName =
+    dependencies.defaultCategoryName ?? DEFAULT_CATEGORY_NAME;
+  const defaultCategoryKind =
+    dependencies.defaultCategoryKind ?? DEFAULT_CATEGORY_KIND;
+
+  async function provision(params: ProvisionAccountParams): Promise<void> {
+    const client = createClient(params.token);
+    const email = resolveEmail(params.email ?? null, params.userId);
+
+    await client.rls(async (tx: RlsTransaction) => {
+      await tx
+        .insert(profiles)
+        .values({
+          id: params.userId,
+          email,
+        })
+        .onConflictDoNothing();
+
+      const existing = await tx
+        .select({ id: categories.id })
+        .from(categories)
+        .where(
+          and(
+            eq(categories.createdBy, params.userId),
+            eq(categories.kind, defaultCategoryKind),
+          ),
+        )
+        .limit(1);
+
+      if (existing.length > 0) {
+        return;
+      }
+
+      await tx.insert(categories).values({
+        name: defaultCategoryName,
+        kind: defaultCategoryKind,
+        createdBy: params.userId,
+        updatedBy: params.userId,
+      });
+    });
+  }
+
+  return { provision };
+}

--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -14,7 +14,7 @@ import {
   profiles,
 } from "@listee/db";
 
-interface ProvisionAccountParams {
+export interface ProvisionAccountParams {
   readonly userId: string;
   readonly token: SupabaseToken;
   readonly email?: string | null;

--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -1,4 +1,9 @@
-import type { Database, RlsClient, RlsTransaction } from "@listee/db";
+import type {
+  Database,
+  RlsClient,
+  RlsTransaction,
+  SupabaseToken,
+} from "@listee/db";
 import {
   and,
   categories,
@@ -8,7 +13,6 @@ import {
   eq,
   profiles,
 } from "@listee/db";
-import type { SupabaseToken } from "@listee/types";
 
 interface ProvisionAccountParams {
   readonly userId: string;

--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -82,27 +82,18 @@ export function createAccountProvisioner(
         })
         .onConflictDoNothing();
 
-      const existing = await tx
-        .select({ id: categories.id })
-        .from(categories)
-        .where(
-          and(
-            eq(categories.createdBy, params.userId),
-            eq(categories.kind, defaultCategoryKind),
-          ),
-        )
-        .limit(1);
-
-      if (existing.length > 0) {
-        return;
-      }
-
-      await tx.insert(categories).values({
-        name: defaultCategoryName,
-        kind: defaultCategoryKind,
-        createdBy: params.userId,
-        updatedBy: params.userId,
-      });
+      await tx
+        .insert(categories)
+        .values({
+          name: defaultCategoryName,
+          kind: defaultCategoryKind,
+          createdBy: params.userId,
+          updatedBy: params.userId,
+        })
+        .onConflictDoNothing({
+          target: [categories.createdBy, categories.name],
+          where: eq(categories.kind, defaultCategoryKind),
+        });
     });
   }
 

--- a/packages/auth/src/authentication/index.ts
+++ b/packages/auth/src/authentication/index.ts
@@ -1,3 +1,6 @@
 export { AuthenticationError } from "./errors.js";
 export { createHeaderAuthentication } from "./header.js";
-export { createSupabaseAuthentication } from "./supabase.js";
+export {
+  createProvisioningSupabaseAuthentication,
+  createSupabaseAuthentication,
+} from "./supabase.js";

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -7,6 +7,7 @@ export type {
 export type {
   AccountProvisioner,
   AccountProvisionerDependencies,
+  ProvisionAccountParams,
 } from "./account/provision-account.js";
 export { createAccountProvisioner } from "./account/provision-account.js";
 export {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,8 +4,14 @@ export type {
   AuthenticationProvider,
   AuthenticationResult,
 } from "@listee/types";
+export type {
+  AccountProvisioner,
+  AccountProvisionerDependencies,
+} from "./account/provision-account.js";
+export { createAccountProvisioner } from "./account/provision-account.js";
 export {
   AuthenticationError,
   createHeaderAuthentication,
+  createProvisioningSupabaseAuthentication,
   createSupabaseAuthentication,
 } from "./authentication/index.js";

--- a/packages/db/src/constants/category.ts
+++ b/packages/db/src/constants/category.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_CATEGORY_NAME = "Inbox";
+export const DEFAULT_CATEGORY_KIND = "system";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { sql } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres, { type Options, type PostgresType, type Sql } from "postgres";
@@ -214,9 +215,8 @@ export function createDrizzle(
 }
 
 export { and, desc, eq, lt, or, sql } from "drizzle-orm";
-
+export * from "./constants/category.js";
 export * from "./schema/index.js";
 
-const schemaModuleUrl = new URL("./schema/index.js", import.meta.url);
-
-export const schemaPath = schemaModuleUrl.pathname;
+const schemaUrl = new URL("./schema/index.js", import.meta.url);
+export const schemaPath = fileURLToPath(schemaUrl.href);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -218,5 +218,16 @@ export { and, desc, eq, lt, or, sql } from "drizzle-orm";
 export * from "./constants/category.js";
 export * from "./schema/index.js";
 
-const schemaUrl = new URL("./schema/index.js", import.meta.url);
-export const schemaPath = fileURLToPath(schemaUrl.href);
+function resolveSchemaPath(): string {
+  try {
+    const schemaUrl = new URL("./schema/index.js", import.meta.url);
+    if (schemaUrl.protocol === "file:") {
+      return fileURLToPath(schemaUrl);
+    }
+    return schemaUrl.pathname;
+  } catch {
+    return "./schema/index.js";
+  }
+}
+
+export const schemaPath = resolveSchemaPath();

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -10,6 +10,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { authenticatedRole } from "drizzle-orm/supabase";
+import { DEFAULT_CATEGORY_KIND } from "../constants/category";
 
 const timestamps = {
   createdAt: timestamp("created_at", { withTimezone: true })
@@ -96,7 +97,7 @@ export const categories = pgTable(
       }),
       uniqueIndex("categories_system_name_idx")
         .on(table.createdBy, table.name)
-        .where(eq(table.kind, "system")),
+        .where(eq(table.kind, DEFAULT_CATEGORY_KIND)),
     ];
   },
 );

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import {
   boolean,
@@ -6,6 +6,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 import { authenticatedRole } from "drizzle-orm/supabase";
@@ -93,6 +94,9 @@ export const categories = pgTable(
         to: authenticatedRole,
         using: isOwner,
       }),
+      uniqueIndex("categories_system_name_idx")
+        .on(table.createdBy, table.name)
+        .where(eq(table.kind, "system")),
     ];
   },
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic account provisioning on sign-in: creates user profiles and a default "Inbox" system category.
  * Supabase provisioning-enabled authentication option that performs provisioning during sign-in.
  * Public account provisioning API and exports for use by other modules.
  * Default category name/kind ("Inbox", "system") now exposed.

* **Database**
  * Prevent duplicate system categories via a new uniqueness constraint.

* **Tests**
  * Added tests for provisioning flow, email capture, and token validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->