### PR TITLE
Support CLI RLS tokens and fix categories index

### DIFF
--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -16,7 +16,7 @@ import {
 
 export interface ProvisionAccountParams {
   readonly userId: string;
-  readonly token: SupabaseToken;
+  readonly token: SupabaseToken | string;
   readonly email?: string | null;
 }
 
@@ -26,7 +26,7 @@ export interface AccountProvisioner {
 
 export interface AccountProvisionerDependencies {
   readonly database?: Database;
-  readonly createRlsClient?: (token: SupabaseToken) => RlsClient;
+  readonly createRlsClient?: (token: SupabaseToken | string) => RlsClient;
   readonly defaultCategoryName?: string;
   readonly defaultCategoryKind?: string;
 }
@@ -51,12 +51,12 @@ function resolveEmail(
 
 function resolveCreateRlsClient(
   dependencies: AccountProvisionerDependencies,
-): (token: SupabaseToken) => RlsClient {
+): (token: SupabaseToken | string) => RlsClient {
   if (dependencies.createRlsClient !== undefined) {
     return dependencies.createRlsClient;
   }
 
-  return (token: SupabaseToken) =>
+  return (token: SupabaseToken | string) =>
     createRlsClient(token, { database: dependencies.database });
 }
 

--- a/packages/auth/src/account/provision-account.ts
+++ b/packages/auth/src/account/provision-account.ts
@@ -5,7 +5,6 @@ import type {
   SupabaseToken,
 } from "@listee/db";
 import {
-  and,
   categories,
   createRlsClient,
   DEFAULT_CATEGORY_KIND,

--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -5,6 +5,8 @@ import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 type ModuleExports = typeof import("./index");
 type CreatePostgresConnection = ModuleExports["createPostgresConnection"];
 type CreateRlsClient = ModuleExports["createRlsClient"];
+type ParseSupabaseAccessToken =
+  ModuleExports["parseSupabaseAccessToken"];
 
 interface PostgresCall {
   url: unknown;
@@ -27,6 +29,8 @@ interface TransactionRecord {
   queries: Array<SqlStatement>;
 }
 
+type ExecuteInterceptor = (query: SqlStatement) => Promise<void>;
+
 function renderSql(statement: SqlStatement): string {
   return statement.strings.join("");
 }
@@ -37,6 +41,7 @@ let connectionCounter = 0;
 const transactionRecords: Array<TransactionRecord> = [];
 const rawValues: Array<unknown> = [];
 let connectionNamespace = 0;
+let executeInterceptor: ExecuteInterceptor | null = null;
 
 function sqlTag(
   strings: TemplateStringsArray,
@@ -114,6 +119,9 @@ mock.module("drizzle-orm/postgres-js", () => ({
         const tx: { execute: (query: SqlStatement) => Promise<void> } = {
           execute: async (query: SqlStatement) => {
             record.queries.push(query);
+            if (executeInterceptor !== null) {
+              await executeInterceptor(query);
+            }
           },
         };
 
@@ -130,14 +138,20 @@ mock.module("drizzle-orm/postgres-js", () => ({
   },
 }));
 
+function setExecuteInterceptor(handler: ExecuteInterceptor | null): void {
+  executeInterceptor = handler;
+}
+
 let createPostgresConnection: CreatePostgresConnection;
 let createRlsClient: CreateRlsClient;
+let parseSupabaseAccessToken: ParseSupabaseAccessToken;
 
 beforeAll(async () => {
   process.env.POSTGRES_URL = "postgres://initial";
   const module = await import("./index");
   createPostgresConnection = module.createPostgresConnection;
   createRlsClient = module.createRlsClient;
+  parseSupabaseAccessToken = module.parseSupabaseAccessToken;
 });
 
 beforeEach(() => {
@@ -146,6 +160,7 @@ beforeEach(() => {
   rawValues.splice(0, rawValues.length);
   connectionNamespace += 1;
   process.env.POSTGRES_URL = `postgres://test-${connectionNamespace}`;
+  setExecuteInterceptor(null);
 });
 
 describe("createPostgresConnection", () => {
@@ -194,6 +209,21 @@ describe("createPostgresConnection", () => {
 });
 
 describe("createRlsClient", () => {
+  function encodeSegment(value: Record<string, unknown>): string {
+    const json = JSON.stringify(value);
+    return Buffer.from(json)
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/u, "");
+  }
+
+  function createAccessToken(payload: Record<string, unknown>): string {
+    const header = encodeSegment({ alg: "none", typ: "JWT" });
+    const body = encodeSegment(payload);
+    return `${header}.${body}.`;
+  }
+
   test("wraps RLS setup and teardown around the transaction", async () => {
     const token = {
       sub: "user-123",
@@ -208,21 +238,45 @@ describe("createRlsClient", () => {
     expect(transactionRecords.length).toBe(1);
 
     const [record] = transactionRecords;
-    expect(record.queries.length).toBe(2);
+    expect(record.queries.length).toBe(8);
 
-    const [setupQuery, teardownQuery] = record.queries;
-    expect(setupQuery.values[0]).toBe(JSON.stringify(token));
-    expect(setupQuery.values[1]).toBe(token.sub);
-    expect(renderSql(setupQuery)).toContain("set_config('request.jwt.claims'");
-    expect(renderSql(setupQuery)).toContain(
+    const [
+      setClaims,
+      setSubject,
+      setRoleClaim,
+      setRole,
+      resetRole,
+      clearRoleClaim,
+      clearSubject,
+      clearClaims,
+    ] = record.queries;
+
+    expect(setClaims.values[0]).toBe(JSON.stringify(token));
+    expect(renderSql(setClaims)).toContain("set_config('request.jwt.claims'");
+
+    expect(setSubject.values[0]).toBe(token.sub);
+    expect(renderSql(setSubject)).toContain(
       "set_config('request.jwt.claim.sub'",
     );
 
-    expect(renderSql(teardownQuery)).toContain(
+    expect(setRoleClaim.values[0]).toBe("anon");
+    expect(renderSql(setRoleClaim)).toContain(
+      "set_config('request.jwt.claim.role'",
+    );
+
+    expect(renderSql(setRole)).toContain("set local role");
+    expect(rawValues.at(-1)).toBe("anon");
+
+    expect(renderSql(resetRole)).toContain("reset role");
+    expect(renderSql(clearRoleClaim)).toContain(
+      "set_config('request.jwt.claim.role', NULL",
+    );
+    expect(renderSql(clearSubject)).toContain(
+      "set_config('request.jwt.claim.sub', NULL",
+    );
+    expect(renderSql(clearClaims)).toContain(
       "set_config('request.jwt.claims', NULL",
     );
-    expect(renderSql(teardownQuery)).toContain("reset role");
-    expect(rawValues.at(-1)).toBe("anon");
   });
 
   test("preserves a valid role value", async () => {
@@ -235,5 +289,53 @@ describe("createRlsClient", () => {
     await client.rls(async () => undefined);
 
     expect(rawValues.at(-1)).toBe("editor");
+  });
+
+  test("throws a descriptive error when local role cannot be set", async () => {
+    setExecuteInterceptor(async (statement) => {
+      const sqlText = renderSql(statement);
+      if (sqlText.includes("set local role")) {
+        const error = new Error('permission denied to set role "authenticated"');
+        (error as { code: string }).code = "42501";
+        throw error;
+      }
+    });
+
+    const token = {
+      sub: "user-222",
+      role: "authenticated",
+    };
+
+    const client = createRlsClient(token);
+    await expect(
+      client.rls(async () => "ok"),
+    ).rejects.toThrow('Failed to set local role "authenticated"');
+  });
+
+  test("accepts a Supabase access token string", async () => {
+    const payload = {
+      sub: "user-456",
+      role: "authenticated",
+    };
+    const accessToken = createAccessToken(payload);
+
+    const client = createRlsClient(accessToken);
+    await client.rls(async () => undefined);
+
+    expect(rawValues.at(-1)).toBe("authenticated");
+  });
+
+  test("parses access token payloads", () => {
+    const payload = {
+      sub: "user-789",
+      role: "authenticated",
+      aud: ["audience"],
+    };
+    const accessToken = createAccessToken(payload);
+    const parsed = parseSupabaseAccessToken(accessToken);
+
+    expect(parsed.sub).toBe(payload.sub);
+    expect(parsed.role).toBe(payload.role);
+    expect(parsed.aud).toEqual(payload.aud);
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -179,11 +179,19 @@ function isSupabaseToken(value: unknown): value is SupabaseToken {
     return false;
   }
 
-  if ("iss" in value && value.iss !== undefined && typeof value.iss !== "string") {
+  if (
+    "iss" in value &&
+    value.iss !== undefined &&
+    typeof value.iss !== "string"
+  ) {
     return false;
   }
 
-  if ("sub" in value && value.sub !== undefined && typeof value.sub !== "string") {
+  if (
+    "sub" in value &&
+    value.sub !== undefined &&
+    typeof value.sub !== "string"
+  ) {
     return false;
   }
 
@@ -194,23 +202,43 @@ function isSupabaseToken(value: unknown): value is SupabaseToken {
     }
   }
 
-  if ("exp" in value && value.exp !== undefined && typeof value.exp !== "number") {
+  if (
+    "exp" in value &&
+    value.exp !== undefined &&
+    typeof value.exp !== "number"
+  ) {
     return false;
   }
 
-  if ("nbf" in value && value.nbf !== undefined && typeof value.nbf !== "number") {
+  if (
+    "nbf" in value &&
+    value.nbf !== undefined &&
+    typeof value.nbf !== "number"
+  ) {
     return false;
   }
 
-  if ("iat" in value && value.iat !== undefined && typeof value.iat !== "number") {
+  if (
+    "iat" in value &&
+    value.iat !== undefined &&
+    typeof value.iat !== "number"
+  ) {
     return false;
   }
 
-  if ("jti" in value && value.jti !== undefined && typeof value.jti !== "string") {
+  if (
+    "jti" in value &&
+    value.jti !== undefined &&
+    typeof value.jti !== "string"
+  ) {
     return false;
   }
 
-  if ("role" in value && value.role !== undefined && typeof value.role !== "string") {
+  if (
+    "role" in value &&
+    value.role !== undefined &&
+    typeof value.role !== "string"
+  ) {
     return false;
   }
 
@@ -348,9 +376,7 @@ function decodeBase64Url(value: string): string {
   const padding = normalized.length % 4;
 
   const padded =
-    padding === 0
-      ? normalized
-      : `${normalized}${"=".repeat(4 - padding)}`;
+    padding === 0 ? normalized : `${normalized}${"=".repeat(4 - padding)}`;
 
   const buffer = Buffer.from(padded, "base64");
   return buffer.toString("utf8");
@@ -411,7 +437,11 @@ function isRolePermissionError(error: unknown): boolean {
 
   if (isRecord(error)) {
     const codeValue = readStringProperty(error, "code");
-    if (codeValue === "42501" || codeValue === "0A000" || codeValue === "28000") {
+    if (
+      codeValue === "42501" ||
+      codeValue === "0A000" ||
+      codeValue === "28000"
+    ) {
       return true;
     }
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { fileURLToPath } from "node:url";
 import { sql } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -161,6 +162,263 @@ export type SupabaseToken = {
   role?: string;
 } & Record<string, unknown>;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  return value.every((item) => typeof item === "string");
+}
+
+function isSupabaseToken(value: unknown): value is SupabaseToken {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if ("iss" in value && value.iss !== undefined && typeof value.iss !== "string") {
+    return false;
+  }
+
+  if ("sub" in value && value.sub !== undefined && typeof value.sub !== "string") {
+    return false;
+  }
+
+  if ("aud" in value && value.aud !== undefined) {
+    const audience = value.aud;
+    if (typeof audience !== "string" && !isStringArray(audience)) {
+      return false;
+    }
+  }
+
+  if ("exp" in value && value.exp !== undefined && typeof value.exp !== "number") {
+    return false;
+  }
+
+  if ("nbf" in value && value.nbf !== undefined && typeof value.nbf !== "number") {
+    return false;
+  }
+
+  if ("iat" in value && value.iat !== undefined && typeof value.iat !== "number") {
+    return false;
+  }
+
+  if ("jti" in value && value.jti !== undefined && typeof value.jti !== "string") {
+    return false;
+  }
+
+  if ("role" in value && value.role !== undefined && typeof value.role !== "string") {
+    return false;
+  }
+
+  return true;
+}
+
+function readStringProperty(
+  value: Record<string, unknown>,
+  key: string,
+): string | null {
+  const candidate = value[key];
+  if (typeof candidate === "string" && candidate.length > 0) {
+    return candidate;
+  }
+
+  return null;
+}
+
+function formatDatabaseErrorDetails(error: unknown): string | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const detailParts: Array<string> = [];
+
+  const code = readStringProperty(error, "code");
+  if (code !== null) {
+    detailParts.push(`code: ${code}`);
+  }
+
+  const detail = readStringProperty(error, "detail");
+  if (detail !== null) {
+    detailParts.push(`detail: ${detail}`);
+  }
+
+  const hint = readStringProperty(error, "hint");
+  if (hint !== null) {
+    detailParts.push(`hint: ${hint}`);
+  }
+
+  const schema = readStringProperty(error, "schema");
+  if (schema !== null) {
+    detailParts.push(`schema: ${schema}`);
+  }
+
+  const table = readStringProperty(error, "table");
+  if (table !== null) {
+    detailParts.push(`table: ${table}`);
+  }
+
+  const column = readStringProperty(error, "column");
+  if (column !== null) {
+    detailParts.push(`column: ${column}`);
+  }
+
+  const constraint = readStringProperty(error, "constraint");
+  if (constraint !== null) {
+    detailParts.push(`constraint: ${constraint}`);
+  }
+
+  if (detailParts.length === 0) {
+    return null;
+  }
+
+  return detailParts.join(", ");
+}
+
+function extractErrorMessage(value: unknown): string | null {
+  if (value instanceof Error) {
+    return value.message;
+  }
+
+  if (isRecord(value)) {
+    const direct = readStringProperty(value, "message");
+    if (direct !== null) {
+      return direct;
+    }
+  }
+
+  return null;
+}
+
+function extractCombinedErrorDetails(error: unknown): {
+  readonly message: string;
+  readonly details: string | null;
+} {
+  const visited = new Set<unknown>();
+  const messages: Array<string> = [];
+  const detailCandidates: Array<string> = [];
+
+  const stack: Array<unknown> = [error];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined || current === null) {
+      continue;
+    }
+
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+
+    const message = extractErrorMessage(current);
+    if (message !== null && !messages.includes(message)) {
+      messages.push(message);
+    }
+
+    const details = formatDatabaseErrorDetails(current);
+    if (details !== null) {
+      detailCandidates.push(details);
+    }
+
+    if (current instanceof Error && current.cause !== undefined) {
+      stack.push(current.cause);
+    } else if (isRecord(current) && "cause" in current) {
+      stack.push(current.cause);
+    }
+  }
+
+  const baseMessage =
+    messages.length > 0 ? messages.join(" | ") : String(error);
+  const combinedDetails =
+    detailCandidates.length > 0
+      ? Array.from(new Set(detailCandidates)).join(" | ")
+      : null;
+
+  return {
+    message: baseMessage,
+    details: combinedDetails,
+  };
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+
+  const padded =
+    padding === 0
+      ? normalized
+      : `${normalized}${"=".repeat(4 - padding)}`;
+
+  const buffer = Buffer.from(padded, "base64");
+  return buffer.toString("utf8");
+}
+
+function extractJwtPayload(accessToken: string): unknown {
+  const trimmed = accessToken.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Supabase access token must not be empty");
+  }
+
+  const segments = trimmed.split(".");
+  if (segments.length < 2) {
+    throw new Error("Supabase access token must be a JWT");
+  }
+
+  const payloadSegment = segments[1];
+
+  try {
+    const decoded = decodeBase64Url(payloadSegment);
+    return JSON.parse(decoded);
+  } catch {
+    throw new Error("Supabase access token payload is invalid");
+  }
+}
+
+export function parseSupabaseAccessToken(accessToken: string): SupabaseToken {
+  const payload = extractJwtPayload(accessToken);
+  if (!isSupabaseToken(payload)) {
+    throw new Error("Supabase access token claims are invalid");
+  }
+
+  return payload;
+}
+
+function resolveSupabaseToken(token: SupabaseToken | string): SupabaseToken {
+  if (isSupabaseToken(token)) {
+    return token;
+  }
+
+  return parseSupabaseAccessToken(token);
+}
+
+function isRolePermissionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const lowerMessage = error.message.toLowerCase();
+
+  if (
+    lowerMessage.includes("permission denied to set role") ||
+    lowerMessage.includes("must be member of role") ||
+    lowerMessage.includes("must be superuser")
+  ) {
+    return true;
+  }
+
+  if (isRecord(error)) {
+    const codeValue = readStringProperty(error, "code");
+    if (codeValue === "42501" || codeValue === "0A000" || codeValue === "28000") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export type RlsTransaction = Parameters<
   Parameters<Database["transaction"]>[0]
 >[0];
@@ -174,32 +432,108 @@ export interface RlsClient {
 }
 
 export function createRlsClient(
-  token: SupabaseToken,
+  token: SupabaseToken | string,
   options?: CreateRlsClientOptions,
 ): RlsClient {
   const database = options?.database ?? getDb();
-  const sanitizedRole = sanitizeRole(token.role);
-  const serializedToken = JSON.stringify(token);
-  const subject = typeof token.sub === "string" ? token.sub : "";
+  const claims = resolveSupabaseToken(token);
+  const sanitizedRole = sanitizeRole(claims.role);
+  const serializedToken = JSON.stringify(claims);
+  const subject = typeof claims.sub === "string" ? claims.sub : "";
 
   async function rls<T>(
     transaction: (tx: RlsTransaction) => Promise<T>,
   ): Promise<T> {
     return database.transaction(async (tx) => {
-      try {
-        await tx.execute(sql`
-          select set_config('request.jwt.claims', ${serializedToken}, TRUE);
-          select set_config('request.jwt.claim.sub', ${subject}, TRUE);
-          set local role ${sql.raw(sanitizedRole)};
-        `);
+      const cleanupTasks: Array<() => Promise<void>> = [];
 
-        return await transaction(tx);
-      } finally {
+      await tx.execute(sql`
+        select set_config('request.jwt.claims', ${serializedToken}, TRUE);
+      `);
+      cleanupTasks.push(async () => {
         await tx.execute(sql`
           select set_config('request.jwt.claims', NULL, TRUE);
-          select set_config('request.jwt.claim.sub', NULL, TRUE);
-          reset role;
         `);
+      });
+
+      await tx.execute(sql`
+        select set_config('request.jwt.claim.sub', ${subject}, TRUE);
+      `);
+      cleanupTasks.push(async () => {
+        await tx.execute(sql`
+          select set_config('request.jwt.claim.sub', NULL, TRUE);
+        `);
+      });
+
+      const roleSetting = sanitizedRole;
+
+      await tx.execute(sql`
+        select set_config('request.jwt.claim.role', ${roleSetting}, TRUE);
+      `);
+      cleanupTasks.push(async () => {
+        await tx.execute(sql`
+          select set_config('request.jwt.claim.role', NULL, TRUE);
+        `);
+      });
+
+      const applyRole = async (): Promise<void> => {
+        await tx.execute(sql`
+          set local role ${sql.raw(sanitizedRole)};
+        `);
+        cleanupTasks.push(async () => {
+          await tx.execute(sql`
+            reset role;
+          `);
+        });
+      };
+
+      try {
+        await applyRole();
+      } catch (error) {
+        if (isRolePermissionError(error)) {
+          const message = `Failed to set local role "${sanitizedRole}". Grant the database user membership in that role so Supabase RLS policies can run.`;
+          if (error instanceof Error) {
+            throw new Error(message, { cause: error });
+          }
+          throw new Error(message);
+        }
+        throw error;
+      }
+
+      const runCleanup = async (propagateErrors: boolean): Promise<void> => {
+        const cleanupErrors: Array<unknown> = [];
+        for (const cleanupTask of [...cleanupTasks].reverse()) {
+          try {
+            await cleanupTask();
+          } catch (cleanupError) {
+            if (propagateErrors) {
+              cleanupErrors.push(cleanupError);
+            }
+          }
+        }
+
+        if (propagateErrors && cleanupErrors.length > 0) {
+          const [firstError] = cleanupErrors;
+          if (firstError instanceof Error) {
+            throw firstError;
+          }
+          throw new Error("Failed to clean up RLS context");
+        }
+      };
+
+      try {
+        const result = await transaction(tx);
+        await runCleanup(true);
+        return result;
+      } catch (error) {
+        await runCleanup(false);
+        const { message: baseMessage, details } =
+          extractCombinedErrorDetails(error);
+        const combinedMessage =
+          details === null ? baseMessage : `${baseMessage} (${details})`;
+        throw new Error(`RLS transaction failed: ${combinedMessage}`, {
+          cause: error instanceof Error ? error : undefined,
+        });
       }
     });
   }
@@ -208,7 +542,7 @@ export function createRlsClient(
 }
 
 export function createDrizzle(
-  token: SupabaseToken,
+  token: SupabaseToken | string,
   options?: CreateRlsClientOptions,
 ): RlsClient {
   return createRlsClient(token, options);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import {
   boolean,
@@ -99,9 +99,7 @@ export const categories = pgTable(
         .on(table.createdBy, table.name)
         // drizzle-kit stringifies template parameters as placeholders, so use sql.raw
         // to inject the literal value without producing $1 in the generated migration.
-        .where(
-          sql`${table.kind} = ${sql.raw(`'${DEFAULT_CATEGORY_KIND}'`)}`,
-        ),
+        .where(sql`${table.kind} = ${sql.raw(`'${DEFAULT_CATEGORY_KIND}'`)}`),
     ];
   },
 );

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -10,7 +10,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { authenticatedRole } from "drizzle-orm/supabase";
-import { DEFAULT_CATEGORY_KIND } from "../constants/category";
+import { DEFAULT_CATEGORY_KIND } from "../constants/category.js";
 
 const timestamps = {
   createdAt: timestamp("created_at", { withTimezone: true })
@@ -97,7 +97,11 @@ export const categories = pgTable(
       }),
       uniqueIndex("categories_system_name_idx")
         .on(table.createdBy, table.name)
-        .where(eq(table.kind, DEFAULT_CATEGORY_KIND)),
+        // drizzle-kit stringifies template parameters as placeholders, so use sql.raw
+        // to inject the literal value without producing $1 in the generated migration.
+        .where(
+          sql`${table.kind} = ${sql.raw(`'${DEFAULT_CATEGORY_KIND}'`)}`,
+        ),
     ];
   },
 );


### PR DESCRIPTION
## Summary
- allow the RLS client to accept raw Supabase access tokens and surface detailed Postgres errors
- keep provisioning logic in sync so the CLI can reuse the same token handling
- generate the categories_system_name_idx filter as a literal to avoid  placeholders in migrations

## Testing
- bun test packages/db/src/index.test.ts
- bun run build --filter @listee/db


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * APIs now accept JWT strings as well as token objects.
  * Added parseSupabaseAccessToken for explicit JWT parsing.

* **Improvements**
  * Stronger RLS transaction lifecycle: setup/cleanup of JWT and role context with clearer error reporting.
  * createRlsClient/createDrizzle updated to handle token strings.

* **Tests**
  * Expanded tests for token parsing, role handling, and permission-error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->