### PR TITLE
Add release job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   lint:
     uses: listee-dev/listee-ci/.github/workflows/lint.yml@main
@@ -14,3 +19,12 @@ jobs:
 
   test:
     uses: listee-dev/listee-ci/.github/workflows/test.yml@main
+
+  release:
+    needs:
+      - lint
+      - typecheck
+      - test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: listee-dev/listee-ci/.github/workflows/release.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- call the shared release workflow after lint, typecheck, and test succeed on main pushes

## Testing
- not run (workflow change only)]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to add workflow permissions and an automated release job that runs after lint/typecheck/tests and triggers on pushes to main.

---

Note: This release contains infrastructure improvements with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->