### PR TITLE
Ensure CI runs for release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - changeset-release/**
+      - release/**
   pull_request:
+    branches:
+      - "**"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- trigger the shared ci workflow when changeset-release/* or release/* branches are pushed
- explicitly allow all pull request branches so release PRs pick up status checks

## Testing
- not run (workflow change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow to improve automated testing and release automation across additional branch patterns, ensuring more consistent code quality and faster deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->