### PR TITLE
Declare publish config for npm provenance

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -2,6 +2,10 @@
   "name": "@listee/api",
   "version": "0.2.0",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -2,6 +2,10 @@
   "name": "@listee/auth",
   "version": "0.2.0",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,6 +2,10 @@
   "name": "@listee/db",
   "version": "0.2.0",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,10 @@
   "name": "@listee/types",
   "version": "0.2.0",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- mark each package as public with npm provenance enabled so trusted publishing works

## Testing
- not run (metadata change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration across multiple packages to enable public distribution and provenance metadata tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->