### PR TITLE
Add repository metadata for packages

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,10 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/listee-dev/listee-libs.git"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,6 +12,10 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/listee-dev/listee-libs.git"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,6 +12,10 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/listee-dev/listee-libs.git"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,6 +12,10 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/listee-dev/listee-libs.git"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.build.json",


### PR DESCRIPTION
## Summary
- add a GitHub repository field to each package.json so npm provenance validation succeeds

## Testing
- not run (metadata change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository metadata to package manifests across API, Auth, DB, and Types packages for improved package management and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->