### PR TITLE
Add package READMEs and MIT licenses

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,50 @@
+# @listee/api
+
+HTTP-facing application utilities for Listee. The package wires queries, services, and repositories so Hono route handlers can expose category/task endpoints and health checks with minimal boilerplate.
+
+## Installation
+
+```bash
+npm install @listee/api
+```
+
+## Features
+
+- `createApp` helper that returns a fully wired Hono instance
+- Register functions for categories, tasks, and health routes
+- Query facades that coordinate services and repositories per use case
+- Validation utilities shared across handlers to enforce input constraints
+
+## Quick start
+
+```ts
+import { Hono } from "hono";
+import {
+  createCategoryQueries,
+  createTaskQueries,
+  registerCategoryRoutes,
+  registerTaskRoutes,
+} from "@listee/api";
+
+const app = new Hono();
+
+const categoryQueries = createCategoryQueries(/* dependencies */);
+const taskQueries = createTaskQueries(/* dependencies */);
+
+registerCategoryRoutes(app, { queries: categoryQueries });
+registerTaskRoutes(app, { queries: taskQueries });
+
+export default app;
+```
+
+All queries accept factories so tests can inject fakes/mocks. See `src/queries/` and `src/routes/` for concrete wiring examples.
+
+## Development
+
+- Build: `bun run build`
+- Tests: `bun test`
+- Lint: `bun run lint`
+
+## License
+
+MIT

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,6 +6,7 @@
     "access": "public",
     "provenance": true
   },
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,45 @@
+# @listee/auth
+
+Authentication and provisioning helpers for Listee services. This package ships reusable providers that validate requests (e.g., Supabase JWTs) and optional hooks for post-auth account provisioning.
+
+## Installation
+
+```bash
+npm install @listee/auth
+```
+
+## Features
+
+- Header-based development authentication with `createHeaderAuthentication`
+- Production-ready Supabase verifier via `createSupabaseAuthentication`
+- Account provisioning wrapper `createProvisioningSupabaseAuthentication`
+- Strongly typed `AuthenticatedUser` and `AuthenticationContext` exports
+
+## Quick start
+
+```ts
+import { createSupabaseAuthentication } from "@listee/auth";
+
+const authenticate = createSupabaseAuthentication({
+  jwksUrl: new URL("https://<project>.supabase.co/auth/v1/.well-known/jwks.json"),
+  expectedAudience: "authenticated",
+});
+
+const result = await authenticate({ request, requiredRole: "authenticated" });
+if (result.type === "success") {
+  const user = result.user;
+  // continue with request handling
+}
+```
+
+See `src/authentication/` for additional adapters and tests demonstrating error handling scenarios.
+
+## Development
+
+- Build: `bun run build`
+- Tests: `bun test`
+- Lint: `bun run lint`
+
+## License
+
+MIT

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,6 +6,7 @@
     "access": "public",
     "provenance": true
   },
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,45 @@
+# @listee/db
+
+Postgres + Drizzle utilities used by Listee services. It provides connection management, row-level security (RLS) helpers, and schema exports for downstream consumers.
+
+## Installation
+
+```bash
+npm install @listee/db
+```
+
+## Features
+
+- Cached `postgres` connections for local development and tests
+- `createRlsClient`/`createDrizzle` to run transactions with Supabase-style claims
+- Schema exports under `schema/` plus category constants for consistent lookups
+- Graceful error wrapping that surfaces detailed Drizzle/Postgres diagnostics
+
+## Quick start
+
+```ts
+import { createRlsClient, createPostgresConnection } from "@listee/db";
+
+const connection = createPostgresConnection();
+
+const rlsClient = createRlsClient({
+  connection,
+});
+
+await rlsClient.runWithToken({ token: jwt }, async (tx) => {
+  const categories = await tx.query.categories.findMany();
+  return categories;
+});
+```
+
+Set `POSTGRES_URL` (or pass `connectionString`) before invoking the helpers. When `reuseConnection` is true (default), connections are cached across calls to reduce overhead.
+
+## Development
+
+- Build: `bun run build`
+- Tests: `bun test`
+- Lint: `bun run lint`
+
+## License
+
+MIT

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,6 +6,7 @@
     "access": "public",
     "provenance": true
   },
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,39 @@
+# @listee/types
+
+Shared TypeScript interfaces used across Listee services and client SDKs. The package aggregates API payloads, authentication contracts, and database types so downstream packages stay in sync.
+
+## Installation
+
+```bash
+npm install @listee/types
+```
+
+## Contents
+
+- `api` — request/response types for Listee REST handlers
+- `authentication` — user/session contracts consumed by `@listee/auth`
+- `db` — database-facing types used by `@listee/db` and repository layers
+
+## Usage
+
+```ts
+import type { AppDependencies, ListCategoriesResult } from "@listee/types";
+
+function listCategories(deps: AppDependencies): Promise<ListCategoriesResult> {
+  return deps.categoryQueries.listCategories({ userId: deps.actor.id });
+}
+```
+
+The package ships only `.d.ts` files, making it safe to use from Node.js and browser contexts.
+
+## Development
+
+Changes flow from the monorepo root:
+
+- Update the relevant source under `src/`
+- Run `bun run build` to emit declaration files into `dist/`
+- Execute `bun test` or higher level tests in dependent packages to ensure compatibility
+
+## License
+
+MIT

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,6 +6,7 @@
     "access": "public",
     "provenance": true
   },
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- add package-level README files for @listee/api, @listee/auth, @listee/db, and @listee/types
- declare the MIT license in each package.json so npm shows correct metadata

## Testing
- not run (docs and metadata only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Release Process section with detailed workflow steps and publishing requirements
  * Added comprehensive package documentation for @listee/api, @listee/auth, @listee/db, and @listee/types packages

* **Chores**
  * Added MIT license field to package metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->