### PR TITLE
Include docs and semver dependencies in published packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "drizzle-orm": "^0.44.5",
     "hono": "^4.4.4",
     "postgres": "^3.4.7",
-    "jose": "^5.2.3"
+    "jose": "^5.2.3",
+    "@listee/auth": "^0.2.0",
+    "@listee/db": "^0.2.0",
+    "@listee/types": "^0.2.0"
   },
   "workspaces": [
     "packages/*"

--- a/packages/api/LICENSE
+++ b/packages/api/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Listee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,9 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "repository": {
     "type": "git",
@@ -23,9 +25,9 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
-    "@listee/auth": "workspace:*",
-    "@listee/db": "workspace:*",
-    "@listee/types": "workspace:*",
+    "@listee/auth": "catalog:",
+    "@listee/db": "catalog:",
+    "@listee/types": "catalog:",
     "hono": "catalog:"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,9 +25,9 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
-    "@listee/auth": "catalog:",
-    "@listee/db": "catalog:",
-    "@listee/types": "catalog:",
+    "@listee/auth": "workspace:^",
+    "@listee/db": "workspace:^",
+    "@listee/types": "workspace:^",
     "hono": "catalog:"
   }
 }

--- a/packages/auth/LICENSE
+++ b/packages/auth/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Listee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,8 +25,8 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
-    "@listee/db": "catalog:",
-    "@listee/types": "catalog:",
+    "@listee/db": "workspace:^",
+    "@listee/types": "workspace:^",
     "jose": "catalog:"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -11,7 +11,9 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "repository": {
     "type": "git",
@@ -23,8 +25,8 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
-    "@listee/db": "workspace:^",
-    "@listee/types": "workspace:^",
+    "@listee/db": "catalog:",
+    "@listee/types": "catalog:",
     "jose": "catalog:"
   }
 }

--- a/packages/db/LICENSE
+++ b/packages/db/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Listee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,9 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "repository": {
     "type": "git",

--- a/packages/types/LICENSE
+++ b/packages/types/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Listee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,6 +25,6 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
-    "@listee/db": "catalog:"
+    "@listee/db": "workspace:^"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,9 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "repository": {
     "type": "git",
@@ -23,6 +25,6 @@
     "postbuild": "node ../../scripts/write-dist-manifest.mjs"
   },
   "dependencies": {
-    "@listee/db": "workspace:^"
+    "@listee/db": "catalog:"
   }
 }


### PR DESCRIPTION
## Summary
- add README and LICENSE to the published files list for each package
- replace workspace/catalog references with semver ranges during dist manifest generation
- ensure @listee packages resolve via the root catalog when published to npm

## Testing
- bun run build (verifies dist/package.json contains semver ranges)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added MIT license files across packages and included README and LICENSE in published package manifests.
  * Added three internal packages to the project catalog to standardize package references.

* **Refactor**
  * Improved manifest generation to resolve and substitute internal package references with concrete versions when producing release manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->