### PR TITLE
Use dist manifests for publish

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "directory": "dist"
   },
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "directory": "dist"
   },
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "directory": "dist"
   },
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "publishConfig": {
     "access": "public",
-    "provenance": true
+    "provenance": true,
+    "directory": "dist"
   },
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- ensure publishConfig points to dist for monorepo packages
- allows npm tarballs to include semver dependencies generated in dist manifest



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration to explicitly specify distribution directory settings across multiple packages. This ensures consistent artifact publishing behavior without user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->