### PR TITLE
Implement update and delete endpoints for categories and tasks

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -145,6 +145,49 @@ describe("category routes", () => {
     expect(body.data.name).toBe("Inbox");
     expect(body.data.kind).toBe("user");
   });
+
+  test("updates category for a user", async () => {
+    const { categoryQueries, categories } = createCategoryQueries();
+    const authentication = createHeaderAuthentication();
+    const app = createApp({ categoryQueries, authentication });
+    const target = categories[0];
+
+    const response = await app.fetch(
+      createRequest(`/categories/${target.id}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${target.createdBy}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Updated Category" }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe("Updated Category");
+  });
+
+  test("deletes category for a user", async () => {
+    const { categoryQueries, categories } = createCategoryQueries();
+    const authentication = createHeaderAuthentication();
+    const app = createApp({ categoryQueries, authentication });
+    const target = categories[0];
+
+    const response = await app.fetch(
+      createRequest(`/categories/${target.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${target.createdBy}` },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    const deleted = await categoryQueries.findById({
+      categoryId: target.id,
+      userId: target.createdBy,
+    });
+    expect(deleted).toBeNull();
+  });
 });
 
 describe("task routes", () => {
@@ -231,6 +274,46 @@ describe("task routes", () => {
     expect(body.data.name).toBe("New Task");
     expect(body.data.categoryId).toBe(category.id);
   });
+
+  test("updates task for a user", async () => {
+    const { taskQueries, tasks } = createTaskQueries();
+    const authentication = createHeaderAuthentication();
+    const app = createApp({ taskQueries, authentication });
+    const target = tasks[0];
+
+    const response = await app.fetch(
+      createRequest(`/tasks/${target.id}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${target.createdBy}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ isChecked: true }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.isChecked).toBe(true);
+  });
+
+  test("deletes task for a user", async () => {
+    const { taskQueries, tasks } = createTaskQueries();
+    const authentication = createHeaderAuthentication();
+    const app = createApp({ taskQueries, authentication });
+    const target = tasks[0];
+
+    const response = await app.fetch(
+      createRequest(`/tasks/${target.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${target.createdBy}` },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    const deleted = await taskQueries.findById({ taskId: target.id });
+    expect(deleted).toBeNull();
+  });
 });
 
 function createCategoryQueries(): {
@@ -289,6 +372,39 @@ function createCategoryQueries(): {
       categories.unshift(newCategory);
       return newCategory;
     },
+    update: async ({ categoryId, userId, name, kind }) => {
+      const index = categories.findIndex(
+        (item) => item.id === categoryId && item.createdBy === userId,
+      );
+
+      if (index === -1) {
+        return null;
+      }
+
+      const current = categories[index];
+      const updated: Category = {
+        ...current,
+        name: name ?? current.name,
+        kind: kind ?? current.kind,
+        updatedBy: userId,
+        updatedAt: new Date("2024-01-05T00:00:00Z"),
+      };
+
+      categories[index] = updated;
+      return updated;
+    },
+    delete: async ({ categoryId, userId }) => {
+      const index = categories.findIndex(
+        (item) => item.id === categoryId && item.createdBy === userId,
+      );
+
+      if (index === -1) {
+        return false;
+      }
+
+      categories.splice(index, 1);
+      return true;
+    },
   };
 
   return { categoryQueries, categories };
@@ -325,6 +441,41 @@ function createTaskQueries(): {
       nextTaskId += 1;
       tasks.push(newTask);
       return newTask;
+    },
+    update: async ({ taskId, userId, name, description, isChecked }) => {
+      const index = tasks.findIndex(
+        (item) => item.id === taskId && item.createdBy === userId,
+      );
+
+      if (index === -1) {
+        return null;
+      }
+
+      const current = tasks[index];
+      const updated: Task = {
+        ...current,
+        name: name ?? current.name,
+        description:
+          description !== undefined ? description : current.description,
+        isChecked: isChecked ?? current.isChecked,
+        updatedBy: userId,
+        updatedAt: new Date("2024-01-05T00:00:00Z"),
+      };
+
+      tasks[index] = updated;
+      return updated;
+    },
+    delete: async ({ taskId, userId }) => {
+      const index = tasks.findIndex(
+        (item) => item.id === taskId && item.createdBy === userId,
+      );
+
+      if (index === -1) {
+        return false;
+      }
+
+      tasks.splice(index, 1);
+      return true;
     },
   };
 

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -372,7 +372,7 @@ function createCategoryQueries(): {
       categories.unshift(newCategory);
       return newCategory;
     },
-    update: async ({ categoryId, userId, name, kind }) => {
+    update: async ({ categoryId, userId, name }) => {
       const index = categories.findIndex(
         (item) => item.id === categoryId && item.createdBy === userId,
       );
@@ -385,7 +385,6 @@ function createCategoryQueries(): {
       const updated: Category = {
         ...current,
         name: name ?? current.name,
-        kind: kind ?? current.kind,
         updatedBy: userId,
         updatedAt: new Date("2024-01-05T00:00:00Z"),
       };

--- a/packages/api/src/queries/category-queries.ts
+++ b/packages/api/src/queries/category-queries.ts
@@ -2,8 +2,10 @@ import type {
   CategoryQueries,
   CategoryQueriesDependencies,
   CreateCategoryParams,
+  DeleteCategoryParams,
   FindCategoryParams,
   ListCategoriesParams,
+  UpdateCategoryParams,
 } from "@listee/types";
 
 export function createCategoryQueries(
@@ -34,9 +36,27 @@ export function createCategoryQueries(
     });
   }
 
+  async function update(params: UpdateCategoryParams) {
+    return dependencies.service.update({
+      categoryId: params.categoryId,
+      userId: params.userId,
+      name: params.name,
+      kind: params.kind,
+    });
+  }
+
+  async function deleteCategory(params: DeleteCategoryParams) {
+    return dependencies.service.delete({
+      categoryId: params.categoryId,
+      userId: params.userId,
+    });
+  }
+
   return {
     listByUserId,
     findById,
     create,
+    update,
+    delete: deleteCategory,
   };
 }

--- a/packages/api/src/queries/category-queries.ts
+++ b/packages/api/src/queries/category-queries.ts
@@ -41,7 +41,6 @@ export function createCategoryQueries(
       categoryId: params.categoryId,
       userId: params.userId,
       name: params.name,
-      kind: params.kind,
     });
   }
 

--- a/packages/api/src/queries/task-queries.ts
+++ b/packages/api/src/queries/task-queries.ts
@@ -1,9 +1,11 @@
 import type {
   CreateTaskParams,
+  DeleteTaskParams,
   FindTaskParams,
   ListTasksParams,
   TaskQueries,
   TaskQueriesDependencies,
+  UpdateTaskParams,
 } from "@listee/types";
 
 export function createTaskQueries(
@@ -33,9 +35,28 @@ export function createTaskQueries(
     });
   }
 
+  async function update(params: UpdateTaskParams) {
+    return dependencies.service.update({
+      taskId: params.taskId,
+      userId: params.userId,
+      name: params.name,
+      description: params.description,
+      isChecked: params.isChecked,
+    });
+  }
+
+  async function deleteTask(params: DeleteTaskParams) {
+    return dependencies.service.delete({
+      taskId: params.taskId,
+      userId: params.userId,
+    });
+  }
+
   return {
     listByCategory,
     findById,
     create,
+    update,
+    delete: deleteTask,
   };
 }

--- a/packages/api/src/repositories/category-repository.ts
+++ b/packages/api/src/repositories/category-repository.ts
@@ -183,10 +183,6 @@ export function createCategoryRepository(db: Database): CategoryRepository {
       updateData.name = params.name;
     }
 
-    if (params.kind !== undefined) {
-      updateData.kind = params.kind;
-    }
-
     const rows = await db
       .update(categories)
       .set(updateData)

--- a/packages/api/src/repositories/task-repository.ts
+++ b/packages/api/src/repositories/task-repository.ts
@@ -1,5 +1,5 @@
 import type { Database } from "@listee/db";
-import { and, categories, eq, or, tasks } from "@listee/db";
+import { and, categories, desc, eq, or, tasks } from "@listee/db";
 import type {
   CreateTaskRepositoryParams,
   DeleteTaskRepositoryParams,
@@ -37,7 +37,8 @@ export function createTaskRepository(db: Database): TaskRepository {
       const rows = await db
         .select()
         .from(tasks)
-        .where(eq(tasks.categoryId, params.categoryId));
+        .where(eq(tasks.categoryId, params.categoryId))
+        .orderBy(desc(tasks.createdAt), desc(tasks.id));
 
       return rows;
     }
@@ -54,7 +55,8 @@ export function createTaskRepository(db: Database): TaskRepository {
             eq(categories.createdBy, params.userId),
           ),
         ),
-      );
+      )
+      .orderBy(desc(tasks.createdAt), desc(tasks.id));
 
     return rows.map((row) => row.task);
   }

--- a/packages/api/src/repositories/task-repository.ts
+++ b/packages/api/src/repositories/task-repository.ts
@@ -1,5 +1,5 @@
 import type { Database } from "@listee/db";
-import { and, eq, tasks } from "@listee/db";
+import { and, categories, eq, or, tasks } from "@listee/db";
 import type {
   CreateTaskRepositoryParams,
   DeleteTaskRepositoryParams,
@@ -11,40 +11,85 @@ import type {
 } from "@listee/types";
 
 export function createTaskRepository(db: Database): TaskRepository {
+  async function hasTaskAccess(
+    taskId: string,
+    userId: string,
+  ): Promise<boolean> {
+    const rows = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .innerJoin(categories, eq(tasks.categoryId, categories.id))
+      .where(
+        and(
+          eq(tasks.id, taskId),
+          or(eq(tasks.createdBy, userId), eq(categories.createdBy, userId)),
+        ),
+      )
+      .limit(1);
+
+    return rows.length > 0;
+  }
+
   async function listByCategory(
     params: ListTasksRepositoryParams,
   ): Promise<readonly Task[]> {
-    const rows = await db
-      .select()
-      .from(tasks)
-      .where(eq(tasks.categoryId, params.categoryId));
-
     if (params.userId === undefined) {
+      const rows = await db
+        .select()
+        .from(tasks)
+        .where(eq(tasks.categoryId, params.categoryId));
+
       return rows;
     }
 
-    return rows.filter((task) => task.createdBy === params.userId);
+    const rows = await db
+      .select({ task: tasks })
+      .from(tasks)
+      .innerJoin(categories, eq(tasks.categoryId, categories.id))
+      .where(
+        and(
+          eq(tasks.categoryId, params.categoryId),
+          or(
+            eq(tasks.createdBy, params.userId),
+            eq(categories.createdBy, params.userId),
+          ),
+        ),
+      );
+
+    return rows.map((row) => row.task);
   }
 
   async function findById(
     params: FindTaskRepositoryParams,
   ): Promise<Task | null> {
+    if (params.userId === undefined) {
+      const rows = await db
+        .select()
+        .from(tasks)
+        .where(eq(tasks.id, params.taskId))
+        .limit(1);
+
+      const task = rows[0];
+      return task ?? null;
+    }
+
     const rows = await db
-      .select()
+      .select({ task: tasks })
       .from(tasks)
-      .where(eq(tasks.id, params.taskId))
+      .innerJoin(categories, eq(tasks.categoryId, categories.id))
+      .where(
+        and(
+          eq(tasks.id, params.taskId),
+          or(
+            eq(tasks.createdBy, params.userId),
+            eq(categories.createdBy, params.userId),
+          ),
+        ),
+      )
       .limit(1);
 
-    const task = rows[0];
-    if (task === undefined) {
-      return null;
-    }
-
-    if (params.userId !== undefined && task.createdBy !== params.userId) {
-      return null;
-    }
-
-    return task;
+    const row = rows[0];
+    return row?.task ?? null;
   }
 
   async function create(params: CreateTaskRepositoryParams): Promise<Task> {
@@ -88,26 +133,30 @@ export function createTaskRepository(db: Database): TaskRepository {
       updateData.isChecked = params.isChecked;
     }
 
+    const canAccess = await hasTaskAccess(params.taskId, params.userId);
+    if (!canAccess) {
+      return null;
+    }
+
     const rows = await db
       .update(tasks)
       .set(updateData)
-      .where(
-        and(eq(tasks.id, params.taskId), eq(tasks.createdBy, params.userId)),
-      )
+      .where(eq(tasks.id, params.taskId))
       .returning();
 
     const task = rows[0];
     return task ?? null;
   }
 
-  async function deleteTask(
-    params: DeleteTaskRepositoryParams,
-  ): Promise<boolean> {
+  async function _delete(params: DeleteTaskRepositoryParams): Promise<boolean> {
+    const canAccess = await hasTaskAccess(params.taskId, params.userId);
+    if (!canAccess) {
+      return false;
+    }
+
     const rows = await db
       .delete(tasks)
-      .where(
-        and(eq(tasks.id, params.taskId), eq(tasks.createdBy, params.userId)),
-      )
+      .where(eq(tasks.id, params.taskId))
       .returning({ id: tasks.id });
 
     return rows.length > 0;
@@ -118,6 +167,6 @@ export function createTaskRepository(db: Database): TaskRepository {
     findById,
     create,
     update,
-    delete: deleteTask,
+    delete: _delete,
   };
 }

--- a/packages/api/src/repositories/task-repository.ts
+++ b/packages/api/src/repositories/task-repository.ts
@@ -92,10 +92,7 @@ export function createTaskRepository(db: Database): TaskRepository {
       .update(tasks)
       .set(updateData)
       .where(
-        and(
-          eq(tasks.id, params.taskId),
-          eq(tasks.createdBy, params.userId),
-        ),
+        and(eq(tasks.id, params.taskId), eq(tasks.createdBy, params.userId)),
       )
       .returning();
 
@@ -109,10 +106,7 @@ export function createTaskRepository(db: Database): TaskRepository {
     const rows = await db
       .delete(tasks)
       .where(
-        and(
-          eq(tasks.id, params.taskId),
-          eq(tasks.createdBy, params.userId),
-        ),
+        and(eq(tasks.id, params.taskId), eq(tasks.createdBy, params.userId)),
       )
       .returning({ id: tasks.id });
 

--- a/packages/api/src/routes/categories.ts
+++ b/packages/api/src/routes/categories.ts
@@ -58,17 +58,12 @@ function parseUpdateCategoryPayload(
     return null;
   }
 
-  const hasName = "name" in value;
   if ("kind" in value) {
     return null;
   }
 
-  if (!hasName) {
-    return null;
-  }
-
   let name: string | undefined;
-  if (hasName) {
+  if ("name" in value) {
     const nameValue = value.name;
     if (!isNonEmptyString(nameValue)) {
       return null;

--- a/packages/api/src/routes/categories.ts
+++ b/packages/api/src/routes/categories.ts
@@ -29,7 +29,6 @@ interface CreateCategoryPayload {
 
 interface UpdateCategoryPayload {
   readonly name?: string;
-  readonly kind?: string;
 }
 
 function parseCreateCategoryPayload(
@@ -60,9 +59,11 @@ function parseUpdateCategoryPayload(
   }
 
   const hasName = "name" in value;
-  const hasKind = "kind" in value;
+  if ("kind" in value) {
+    return null;
+  }
 
-  if (!hasName && !hasKind) {
+  if (!hasName) {
     return null;
   }
 
@@ -76,17 +77,7 @@ function parseUpdateCategoryPayload(
     name = nameValue.trim();
   }
 
-  let kind: string | undefined;
-  if (hasKind) {
-    const kindValue = value.kind;
-    if (!isNonEmptyString(kindValue)) {
-      return null;
-    }
-
-    kind = kindValue.trim();
-  }
-
-  return { name, kind };
+  return { name };
 }
 
 function toCategoryResponse(category: {
@@ -250,7 +241,6 @@ export function registerCategoryRoutes(
         categoryId: context.req.param("categoryId"),
         userId: authResult.user.id,
         name: payload.name,
-        kind: payload.kind,
       });
 
       if (category === null) {

--- a/packages/api/src/routes/categories.ts
+++ b/packages/api/src/routes/categories.ts
@@ -27,6 +27,11 @@ interface CreateCategoryPayload {
   readonly kind: string;
 }
 
+interface UpdateCategoryPayload {
+  readonly name?: string;
+  readonly kind?: string;
+}
+
 function parseCreateCategoryPayload(
   value: unknown,
 ): CreateCategoryPayload | null {
@@ -45,6 +50,43 @@ function parseCreateCategoryPayload(
     name: nameValue.trim(),
     kind: kindValue.trim(),
   };
+}
+
+function parseUpdateCategoryPayload(
+  value: unknown,
+): UpdateCategoryPayload | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const hasName = "name" in value;
+  const hasKind = "kind" in value;
+
+  if (!hasName && !hasKind) {
+    return null;
+  }
+
+  let name: string | undefined;
+  if (hasName) {
+    const nameValue = value.name;
+    if (!isNonEmptyString(nameValue)) {
+      return null;
+    }
+
+    name = nameValue.trim();
+  }
+
+  let kind: string | undefined;
+  if (hasKind) {
+    const kindValue = value.kind;
+    if (!isNonEmptyString(kindValue)) {
+      return null;
+    }
+
+    kind = kindValue.trim();
+  }
+
+  return { name, kind };
 }
 
 function toCategoryResponse(category: {
@@ -180,6 +222,64 @@ export function registerCategoryRoutes(
       });
 
       return context.json({ data: toCategoryResponse(category) }, 201);
+    } catch (error) {
+      return context.json({ error: toErrorMessage(error) }, 500);
+    }
+  });
+
+  app.patch("/categories/:categoryId", async (context) => {
+    const authResult = await tryAuthenticate(authentication, context.req.raw);
+    if (authResult === null) {
+      return context.json({ error: "Unauthorized" }, 401);
+    }
+
+    let payloadSource: unknown;
+    try {
+      payloadSource = await context.req.json();
+    } catch {
+      return context.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const payload = parseUpdateCategoryPayload(payloadSource);
+    if (payload === null) {
+      return context.json({ error: "Invalid request body" }, 400);
+    }
+
+    try {
+      const category = await queries.update({
+        categoryId: context.req.param("categoryId"),
+        userId: authResult.user.id,
+        name: payload.name,
+        kind: payload.kind,
+      });
+
+      if (category === null) {
+        return context.json({ error: "Not Found" }, 404);
+      }
+
+      return context.json({ data: toCategoryResponse(category) });
+    } catch (error) {
+      return context.json({ error: toErrorMessage(error) }, 500);
+    }
+  });
+
+  app.delete("/categories/:categoryId", async (context) => {
+    const authResult = await tryAuthenticate(authentication, context.req.raw);
+    if (authResult === null) {
+      return context.json({ error: "Unauthorized" }, 401);
+    }
+
+    try {
+      const deleted = await queries.delete({
+        categoryId: context.req.param("categoryId"),
+        userId: authResult.user.id,
+      });
+
+      if (!deleted) {
+        return context.json({ error: "Not Found" }, 404);
+      }
+
+      return context.newResponse(null, 204);
     } catch (error) {
       return context.json({ error: toErrorMessage(error) }, 500);
     }

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -76,7 +76,9 @@ function parseUpdateTaskPayload(value: unknown): UpdateTaskPayload | null {
     return null;
   }
 
-  const payload: UpdateTaskPayload = {};
+  let name: string | undefined;
+  let description: string | null | undefined;
+  let isChecked: boolean | undefined;
 
   if (hasName) {
     const nameValue = value.name;
@@ -84,7 +86,7 @@ function parseUpdateTaskPayload(value: unknown): UpdateTaskPayload | null {
       return null;
     }
 
-    payload.name = nameValue.trim();
+    name = nameValue.trim();
   }
 
   if (hasDescription) {
@@ -97,10 +99,10 @@ function parseUpdateTaskPayload(value: unknown): UpdateTaskPayload | null {
       return null;
     }
 
-    payload.description =
+    description =
       typeof descriptionValue === "string"
         ? descriptionValue.trim()
-        : descriptionValue ?? null;
+        : (descriptionValue ?? null);
   }
 
   if (hasIsChecked) {
@@ -109,8 +111,14 @@ function parseUpdateTaskPayload(value: unknown): UpdateTaskPayload | null {
       return null;
     }
 
-    payload.isChecked = isCheckedValue;
+    isChecked = isCheckedValue;
   }
+
+  const payload = {
+    ...(name !== undefined ? { name } : {}),
+    ...(hasDescription ? { description: description ?? null } : {}),
+    ...(isChecked !== undefined ? { isChecked } : {}),
+  } satisfies UpdateTaskPayload;
 
   return payload;
 }

--- a/packages/api/src/services/category-service.ts
+++ b/packages/api/src/services/category-service.ts
@@ -41,7 +41,6 @@ export function createCategoryService(
       categoryId: params.categoryId,
       userId: params.userId,
       name: params.name,
-      kind: params.kind,
       updatedBy: params.userId,
     });
   }

--- a/packages/api/src/services/category-service.ts
+++ b/packages/api/src/services/category-service.ts
@@ -3,9 +3,11 @@ import type {
   CategoryService,
   CategoryServiceDependencies,
   CreateCategoryParams,
+  DeleteCategoryParams,
   FindCategoryRepositoryParams,
   ListCategoriesRepositoryParams,
   PaginatedResult,
+  UpdateCategoryParams,
 } from "@listee/types";
 
 export function createCategoryService(
@@ -32,9 +34,32 @@ export function createCategoryService(
     });
   }
 
+  async function update(
+    params: UpdateCategoryParams,
+  ): Promise<Category | null> {
+    return dependencies.repository.update({
+      categoryId: params.categoryId,
+      userId: params.userId,
+      name: params.name,
+      kind: params.kind,
+      updatedBy: params.userId,
+    });
+  }
+
+  async function deleteCategory(
+    params: DeleteCategoryParams,
+  ): Promise<boolean> {
+    return dependencies.repository.delete({
+      categoryId: params.categoryId,
+      userId: params.userId,
+    });
+  }
+
   return {
     listByUserId,
     findById,
     create,
+    update,
+    delete: deleteCategory,
   };
 }

--- a/packages/api/src/services/task-service.ts
+++ b/packages/api/src/services/task-service.ts
@@ -1,10 +1,12 @@
 import type {
   CreateTaskParams,
+  DeleteTaskParams,
   FindTaskRepositoryParams,
   ListTasksRepositoryParams,
   Task,
   TaskService,
   TaskServiceDependencies,
+  UpdateTaskParams,
 } from "@listee/types";
 
 export function createTaskService(
@@ -44,9 +46,29 @@ export function createTaskService(
     });
   }
 
+  async function update(params: UpdateTaskParams): Promise<Task | null> {
+    return dependencies.repository.update({
+      taskId: params.taskId,
+      userId: params.userId,
+      name: params.name,
+      description: params.description,
+      isChecked: params.isChecked,
+      updatedBy: params.userId,
+    });
+  }
+
+  async function deleteTask(params: DeleteTaskParams): Promise<boolean> {
+    return dependencies.repository.delete({
+      taskId: params.taskId,
+      userId: params.userId,
+    });
+  }
+
   return {
     listByCategory,
     findById,
     create,
+    update,
+    delete: deleteTask,
   };
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -32,7 +32,6 @@ export interface UpdateCategoryParams {
   readonly categoryId: string;
   readonly userId: string;
   readonly name?: string;
-  readonly kind?: string;
 }
 
 export interface DeleteCategoryParams {
@@ -108,7 +107,6 @@ export interface UpdateCategoryRepositoryParams {
   readonly categoryId: string;
   readonly userId: string;
   readonly name?: string;
-  readonly kind?: string;
   readonly updatedBy: string;
 }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -18,12 +18,26 @@ export interface CategoryQueries {
   listByUserId(params: ListCategoriesParams): Promise<ListCategoriesResult>;
   findById(params: FindCategoryParams): Promise<Category | null>;
   create(params: CreateCategoryParams): Promise<Category>;
+  update(params: UpdateCategoryParams): Promise<Category | null>;
+  delete(params: DeleteCategoryParams): Promise<boolean>;
 }
 
 export interface CreateCategoryParams {
   readonly userId: string;
   readonly name: string;
   readonly kind: string;
+}
+
+export interface UpdateCategoryParams {
+  readonly categoryId: string;
+  readonly userId: string;
+  readonly name?: string;
+  readonly kind?: string;
+}
+
+export interface DeleteCategoryParams {
+  readonly categoryId: string;
+  readonly userId: string;
 }
 
 export interface ListTasksParams {
@@ -40,6 +54,8 @@ export interface TaskQueries {
   listByCategory(params: ListTasksParams): Promise<readonly Task[]>;
   findById(params: FindTaskParams): Promise<Task | null>;
   create(params: CreateTaskParams): Promise<Task>;
+  update(params: UpdateTaskParams): Promise<Task | null>;
+  delete(params: DeleteTaskParams): Promise<boolean>;
 }
 
 export interface CreateTaskParams {
@@ -48,6 +64,19 @@ export interface CreateTaskParams {
   readonly name: string;
   readonly description?: string | null;
   readonly isChecked?: boolean;
+}
+
+export interface UpdateTaskParams {
+  readonly taskId: string;
+  readonly userId: string;
+  readonly name?: string;
+  readonly description?: string | null;
+  readonly isChecked?: boolean;
+}
+
+export interface DeleteTaskParams {
+  readonly taskId: string;
+  readonly userId: string;
 }
 
 export interface DatabaseHealthStatus {
@@ -75,12 +104,27 @@ export interface CreateCategoryRepositoryParams {
   readonly updatedBy: string;
 }
 
+export interface UpdateCategoryRepositoryParams {
+  readonly categoryId: string;
+  readonly userId: string;
+  readonly name?: string;
+  readonly kind?: string;
+  readonly updatedBy: string;
+}
+
+export interface DeleteCategoryRepositoryParams {
+  readonly categoryId: string;
+  readonly userId: string;
+}
+
 export interface CategoryRepository {
   listByUserId(
     params: ListCategoriesRepositoryParams,
   ): Promise<PaginatedResult<Category>>;
   findById(params: FindCategoryRepositoryParams): Promise<Category | null>;
   create(params: CreateCategoryRepositoryParams): Promise<Category>;
+  update(params: UpdateCategoryRepositoryParams): Promise<Category | null>;
+  delete(params: DeleteCategoryRepositoryParams): Promise<boolean>;
 }
 
 export interface CategoryService {
@@ -89,6 +133,8 @@ export interface CategoryService {
   ): Promise<PaginatedResult<Category>>;
   findById(params: FindCategoryRepositoryParams): Promise<Category | null>;
   create(params: CreateCategoryParams): Promise<Category>;
+  update(params: UpdateCategoryParams): Promise<Category | null>;
+  delete(params: DeleteCategoryParams): Promise<boolean>;
 }
 
 export interface CategoryServiceDependencies {
@@ -114,16 +160,34 @@ export interface CreateTaskRepositoryParams {
   readonly updatedBy: string;
 }
 
+export interface UpdateTaskRepositoryParams {
+  readonly taskId: string;
+  readonly userId: string;
+  readonly name?: string;
+  readonly description?: string | null;
+  readonly isChecked?: boolean;
+  readonly updatedBy: string;
+}
+
+export interface DeleteTaskRepositoryParams {
+  readonly taskId: string;
+  readonly userId: string;
+}
+
 export interface TaskRepository {
   listByCategory(params: ListTasksRepositoryParams): Promise<readonly Task[]>;
   findById(params: FindTaskRepositoryParams): Promise<Task | null>;
   create(params: CreateTaskRepositoryParams): Promise<Task>;
+  update(params: UpdateTaskRepositoryParams): Promise<Task | null>;
+  delete(params: DeleteTaskRepositoryParams): Promise<boolean>;
 }
 
 export interface TaskService {
   listByCategory(params: ListTasksRepositoryParams): Promise<readonly Task[]>;
   findById(params: FindTaskRepositoryParams): Promise<Task | null>;
   create(params: CreateTaskParams): Promise<Task>;
+  update(params: UpdateTaskParams): Promise<Task | null>;
+  delete(params: DeleteTaskParams): Promise<boolean>;
 }
 
 export interface TaskServiceDependencies {


### PR DESCRIPTION
## Summary
- add update and delete operations across category and task repositories, services, and queries
- expose PATCH and DELETE HTTP handlers with validation for categories and tasks
- extend shared API types and tests to cover the new lifecycle flows

## Testing
- bun test *(fails: missing workspace dependencies such as @listee/auth, drizzle-orm, jose, and postgres)*
- bun install *(fails: catalog packages cannot be resolved in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb09059e9483318cfec1f51fc55fbc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Categories: PATCH to update name (partial updates supported); DELETE to remove.
  * Tasks: PATCH to update name, description, and completion status; DELETE to remove.
* **Improvements**
  * Endpoints validate payloads, require authentication, and return proper 400/401/404/204 responses.
* **Tests**
  * End-to-end tests added for updating and deleting categories and tasks, including not-found behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->