### PR TITLE
chore: restrict Supabase audience to string

### DIFF
--- a/packages/auth/src/authentication/supabase.ts
+++ b/packages/auth/src/authentication/supabase.ts
@@ -45,20 +45,6 @@ function buildSupabaseJwksUrl(
   return new URL(normalizedPath, projectUrl);
 }
 
-function normalizeAudience(
-  audience: string | readonly string[] | undefined,
-): string | string[] | undefined {
-  if (audience === undefined) {
-    return undefined;
-  }
-
-  if (typeof audience === "string") {
-    return audience;
-  }
-
-  return [...audience];
-}
-
 export function createSupabaseAuthentication(
   options: SupabaseAuthenticationOptions,
 ): AuthenticationProvider {
@@ -67,7 +53,7 @@ export function createSupabaseAuthentication(
   const projectUrl = parseSupabaseProjectUrl(options.projectUrl);
   const issuer = (options.issuer ?? buildSupabaseIssuerUrl(projectUrl)).trim();
   const jwksUrl = buildSupabaseJwksUrl(projectUrl, options.jwksPath);
-  const audience = normalizeAudience(options.audience);
+  const audience = options.audience;
   const requiredRole = options.requiredRole;
   const clockTolerance = options.clockToleranceSeconds;
 

--- a/packages/types/src/authentication.ts
+++ b/packages/types/src/authentication.ts
@@ -21,7 +21,7 @@ export interface AuthenticationProvider {
 
 export interface SupabaseAuthenticationOptions {
   readonly projectUrl: string;
-  readonly audience?: string | readonly string[];
+  readonly audience?: string;
   readonly issuer?: string;
   readonly requiredRole?: string;
   readonly clockToleranceSeconds?: number;


### PR DESCRIPTION
## Summary
- restrict  to a single string
- drop runtime array normalization in supabase auth provider

## Testing
- bun run lint
- bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Supabase authentication's audience parameter now only accepts string values instead of string or array formats.

* **Refactor**
  * Simplified internal audience handling in Supabase authentication by removing intermediate normalization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->